### PR TITLE
Allow null in final output

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -94,7 +94,10 @@ class MergeJsonWebpackPlugin {
     mergeDeep(target, source) {
         if (typeof target == "object" && typeof source == "object") {
             for (const key in source) {
-                if(source[key] instanceof  Array){
+                if (source[key] === null && target[key] === undefined) {
+                    target[key] = null;
+                }
+                else if (source[key] instanceof Array) {
                     if (!target[key]) target[key]=[];
                     //concatenate arrays
                     target[key]= target[key].concat(source[key]);


### PR DESCRIPTION
Great plugin that is easy to set up. However, I found that if I had a null value in a source file, it would result in {} instead of null in the final output. This change seemed to fix that.