### PR TITLE
Glob Options handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,17 @@ npm i merge-jsons-webpack-plugin
 ```
 
 ```javascript
- var MergeJsonWebpackPlugin = require("merge-jsons-webpack-plugin")
- new MergeJsonWebpackPlugin({
-            "files": ['./jsons/file1.json',
-                './jsons/file3.json',
-                './jsons/file2.json'],
-            "output":{
-                "fileName":"./dist/result.json"
-            }
-        })
+var MergeJsonWebpackPlugin = require("merge-jsons-webpack-plugin");
+new MergeJsonWebpackPlugin({
+    "files": [
+        "./jsons/file1.json",
+        "./jsons/file3.json",
+        "./jsons/file2.json"
+    ],
+    "output": {
+        "fileName": "./dist/result.json"
+    }
+});
 ```
 
 ## Details
@@ -34,16 +36,18 @@ npm i merge-jsons-webpack-plugin
   
 1. **By files**  
        If you want to merge group of files use like this.
-      
-```
-    new MergeJsonWebpackPlugin
-       ({                                           
-            "files": ['./jsons/file1.json','./jsons/file3.json','./jsons/file2.json'],
-            "output":{
-                      "fileName":"./dist/result.json"                         
-                     }
-       })
-                       
+
+```javascript
+new MergeJsonWebpackPlugin({
+    "files": [
+        "./jsons/file1.json",
+        "./jsons/file3.json",
+        "./jsons/file2.json"
+    ],
+    "output": {
+        "fileName": "./dist/result.json"
+    }
+});
 ```
        
        
@@ -55,21 +59,27 @@ npm i merge-jsons-webpack-plugin
         
       
 2. **By Patterns**        
-       This plugin uses glob for searching file patterns,please refer glob for usage for sample pattern.       You can specify a pattern to pull all the files that satify the particular pattern and output a single json file.
+       This plugin uses glob for searching file patterns,please refer glob for usage for sample pattern. You can specify a pattern to pull all the files that satify the particular pattern and output a single json file.
                   
-```
-       new MergeJsonWebpackPlugin({
-                   "encoding":"ascii",
-                   "output":{
-                     "groupBy":[
-                                   { "pattern":"{./jsons/module*/en.json,./jsons/file1.json}", 
-                                      "fileName":"./dist/en.json" 
-                                   },
-                                   { "pattern":"{./jsons/module*/es.json,./jsons/file2.json}", 
-                                       "fileName":"./dist/es.json" }
-                               ]        
-                           }
-                  })  
+```javascript
+new MergeJsonWebpackPlugin({
+    "encoding": "ascii",
+    "output": {
+        "groupBy": [
+            {
+                "pattern": "{./jsons/module*/en.json,./jsons/file1.json}", 
+                "fileName": "./dist/en.json" 
+            },
+            {
+                "pattern": "{./jsons/module*/es.json,./jsons/file2.json}", 
+                "fileName":"./dist/es.json"
+            }
+        ]
+    },
+    "globOptions": {
+        "nosort": true
+    }
+});
 ```
    
    
@@ -79,15 +89,17 @@ npm i merge-jsons-webpack-plugin
 |                    | Do **not use** curly brackets if there is only single pattern to consider                                                   | pattern:"./node_modules/**/en.json"                             |
 |                    | **Use** curly brackets to group more than one pattern together                                                              | pattern:"{./node_modules/**/en.json,./src/assets/i18n/en.json}" |
 | groupBy[].fileName | output file name for the corresponding pattern.Relative path from output.path entry                                                                             |                                                                 |
-| encoding      	| Optional,encoding to be used default is utf-8	|       |
+| encoding      	| Optional, encoding to be used default is utf-8	|       |
+| globOptions      	| Optional, [glob options](https://github.com/isaacs/node-glob#options) to change pattern matching behavior	|       |
 
 ## Change Logs   
    
 | Version      	    | Changes                           |
 |--------------------|-----------------------------------|
-| 1.0.8           	| Error handling improved. Now **fileName** is relative path to output path specified   | 
-| 1.0.10           	| File watching feature added, result will be automatically refreshed if json files are modified | 	    
-| 1.0.11           	| Publish issues with previous version |   
+| 1.0.8           	| Error handling improved. Now **fileName** is relative path to output path specified   |
+| 1.0.10           	| File watching feature added, result will be automatically refreshed if json files are modified |
+| 1.0.11           	| Publish issues with previous version |
+| 1.0.12           	| Added glob options handling |
 
 ## Sample
   Please navigate to example folder

--- a/index.js
+++ b/index.js
@@ -23,13 +23,14 @@ class MergeJsonWebpackPlugin {
                     this.processFiles(compilation, files, outputPath).then((result) => { done(); });
                 }
                 else if (groupBy) {
+                    let globOptions = this.options.globOptions != null ? this.options.globOptions : {};
                     if (groupBy.length == 0) {
                         compilation.errors.push('MergeJsonWebpackPlugin: \"groupBy\" must be non empty object');
                     }
                     groupBy.forEach((globs) => {
                         let pattern = globs.pattern;
                         let outputPath = globs.fileName;
-                        this._glob(pattern).then((files) => {
+                        this._glob(pattern, globOptions).then((files) => {
                             this.processFiles(compilation, files, outputPath).then((result) => { done(); });
                         });
                     });
@@ -49,7 +50,7 @@ class MergeJsonWebpackPlugin {
         };
         this.processFiles = (compilation, files, outputPath) => {
             this.fileDependencies = this.fileDependencies.concat(files);
-            var fileContents = files.map(this.readFile);
+            const fileContents = files.map(this.readFile);
             let mergedContents = {};
             return es6_promise_1.Promise.all(fileContents)
                 .then((contents) => {
@@ -128,9 +129,10 @@ class MergeJsonWebpackPlugin {
             }
             return target;
         };
-        this._glob = (pattern) => {
+        this._glob = (pattern, options) => {
             return new es6_promise_1.Promise((resolve, reject) => {
-                new Glob(pattern, { mark: true }, function (err, matches) {
+                const defaultOptions = { mark: true };
+                new Glob(pattern, Object.assign({}, options, defaultOptions), function (err, matches) {
                     if (err) {
                         reject(err);
                     }

--- a/index.ts
+++ b/index.ts
@@ -39,6 +39,7 @@ class MergeJsonWebpackPlugin {
                 let outputPath = output.fileName;
                 this.processFiles(compilation, files, outputPath).then((result: any) => { done(); });
             } else if (groupBy) {
+                let globOptions = this.options.globOptions != null ? this.options.globOptions : {};
                 if (groupBy.length == 0) {
                     compilation.errors.push('MergeJsonWebpackPlugin: \"groupBy\" must be non empty object');
                 }
@@ -46,7 +47,7 @@ class MergeJsonWebpackPlugin {
                 groupBy.forEach((globs: any) => {
                     let pattern = globs.pattern;
                     let outputPath = globs.fileName;
-                    this._glob(pattern).then((files) => {
+                    this._glob(pattern, globOptions).then((files) => {
                         this.processFiles(compilation, files, outputPath).then((result: any) => { done(); });
                     });
                 });
@@ -68,13 +69,13 @@ class MergeJsonWebpackPlugin {
     }
 
     /**
-     * Process array of files 
+     * Process array of files
      */
     processFiles = (compilation: any, files: Array<string>, outputPath: string) => {
         //add files to watcher
         this.fileDependencies = this.fileDependencies.concat(files);
         //handle files
-        var fileContents = files.map(this.readFile);
+        const fileContents = files.map(this.readFile);
         let mergedContents: any = {};
         return Promise.all(fileContents)
             .then((contents) => {
@@ -101,7 +102,7 @@ class MergeJsonWebpackPlugin {
 
 
     /**
-     * this method reads the file and returns content as json object 
+     * this method reads the file and returns content as json object
      */
     readFile = (f: string) => {
 
@@ -178,12 +179,14 @@ class MergeJsonWebpackPlugin {
     /**
      * this returns array of file paths
      * @param pattern
+     * @param options
      * @returns {Promise}
      * @private
      */
-    private _glob = (pattern: string): Promise<Array<string>> => {
+    private _glob = (pattern: string, options?: any): Promise<Array<string>> => {
         return new Promise((resolve, reject) => {
-            new Glob(pattern, { mark: true }, function (err: any, matches: any) {
+            const defaultOptions = { mark: true };
+            new Glob(pattern, { ...options, ...defaultOptions }, function (err: any, matches: any) {
                 if (err) {
                     reject(err);
                 }
@@ -193,4 +196,4 @@ class MergeJsonWebpackPlugin {
     }
 }
 
-export =MergeJsonWebpackPlugin;
+export = MergeJsonWebpackPlugin;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "merge-jsons-webpack-plugin",
     "description": "This plugin is used to merge json files into single json file,using glob or file names",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "author": {
         "email": "sudharsan_tk@yahoo.co.in",
         "name": "Sudharsan Tettu"
@@ -40,9 +40,8 @@
     },
     "main": "index.js",
     "scripts": {
-        "build":"tsc",
+        "build": "tsc",
         "post-install": "typings install",
         "deploy": "npm publish"
     }
 }
-


### PR DESCRIPTION
First of all, many thanks for your great plugin!
We use it in our projects to handle angular components' translations and we came across a couple of scenarios where the order of the to-be-merged JSONs is important, as more specific translations need to override generic ones.

By using the glob option `nosort`, we are able to achieve that.
Example:
```
      new MergeJsonWebpackPlugin({
          output: {
              groupBy: [
                  {
                      pattern: '{./node_modules/generic-lib/assets/i18n/en.json,./src/assets/i18n/en.json,./node_modules/specific-lib/src/**/i18n/en.json,./src/app/**/i18n/en.json}',
                      fileName: './assets/i18n/merged-en.json'
                  }
              ]
          },
          globOptions: {
              nosort: true
          }
      })
```