### PR TITLE
update API call that was deprecated in Webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ const allowedExtensions = ".json";
 class MergeJsonWebpackPlugin {
     constructor(options) {
         this.apply = (compiler) => {
-            compiler.plugin('emit', (compilation, done) => {
+            const extensionName = "MergeJsonWebpackPlugin";
+            compiler.hooks.emit.tapAsync(extensionName, (compilation, done) => {
                 this.logger.debug('MergeJsonsWebpackPlugin emit started...');
                 this.fileDependencies = [];
                 let files = this.options.files;
@@ -59,7 +60,7 @@ class MergeJsonWebpackPlugin {
                 }
                 this.logger.debug('MergeJsonsWebpackPlugin emit completed...');
             });
-            compiler.plugin("after-emit", (compilation, callback) => {
+            compiler.hooks.afterEmit.tapAsync(extensionName, (compilation, callback) => {
                 this.logger.debug("MergeJsonsWebpackPlugin after-emit starts...");
                 const compilationFileDependencies = new Set(compilation.fileDependencies);
                 this.fileDependencies.forEach((file) => {

--- a/index.ts
+++ b/index.ts
@@ -23,7 +23,8 @@ class MergeJsonWebpackPlugin {
 
 
     apply = (compiler: any) => {
-        compiler.plugin('emit', (compilation, done) => {
+        const extensionName = "MergeJsonWebpackPlugin";
+        compiler.hooks.emit.tapAsync(extensionName, (compilation, done) => {
             this.logger.debug('MergeJsonsWebpackPlugin emit started...');
             //initialize fileDependency array
             this.fileDependencies = [];
@@ -78,7 +79,7 @@ class MergeJsonWebpackPlugin {
             this.logger.debug('MergeJsonsWebpackPlugin emit completed...');
         });
 
-        compiler.plugin("after-emit", (compilation, callback) => {
+        compiler.hooks.afterEmit.tapAsync(extensionName, (compilation, callback) => {
             this.logger.debug("MergeJsonsWebpackPlugin after-emit starts...");
             const compilationFileDependencies = new Set(compilation.fileDependencies);
             this.fileDependencies.forEach((file) => {


### PR DESCRIPTION
```
(node:797) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
    at MergeJsonWebpackPlugin.apply (/private/tmp/jh/jhipster-demo/node_modules/merge-jsons-webpack-plugin/index.js:12:22)
    at webpack (/private/tmp/jh/jhipster-demo/node_modules/webpack/lib/webpack.js:37:12)
    at processOptions (/private/tmp/jh/jhipster-demo/node_modules/webpack-cli/bin/webpack.js:437:16)
```

BTW your package is used in [JHipster](http://jhipster.github.io/) for merging our i18n JSON files, thanks for your work 😄 