### PR TITLE
Add support for JSON files with BOM bytes

### DIFF
--- a/example/app/bom-bytes/bom-bytes.json
+++ b/example/app/bom-bytes/bom-bytes.json
@@ -1,0 +1,4 @@
+﻿{
+  "what": "this file contains BOM bytes. 好的"
+}
+ 

--- a/example/app/expected/bom-bytes.json
+++ b/example/app/expected/bom-bytes.json
@@ -1,0 +1,1 @@
+{"what":"this file contains BOM bytes. 好的"}

--- a/example/webpack.test.config.js
+++ b/example/webpack.test.config.js
@@ -110,7 +110,21 @@ module.exports = {
       "output": {
         "fileName": "prefixfilename/prefixFileName.json"
       }
-    })
+    }),
+
+    /**
+     * This file contains the 3 BOM bytes EF BB BF
+     * The library should be able to look pass them and
+     * still parse the JSON file.
+     * Fourth byte should be a `{` character, hex: 7B
+     */
+    new MergeJsonWebpackPlugin({
+      "debug":false,
+      "files": ['app/bom-bytes/bom-bytes.json'], // Check this file with a HEX viewer.
+      "output": {
+        "fileName": "bom-bytes/bom-bytes.json"
+      }
+    }), 
      
   ]
 };

--- a/index.js
+++ b/index.js
@@ -124,6 +124,13 @@ class MergeJsonWebpackPlugin {
             try {
                 let filePath = path.join(contextPath, f);
                 entryData = fs.readFileSync(filePath, this.options.encoding);
+
+                // Source: https://github.com/sindresorhus/strip-bom/blob/master/index.js
+                // Catches EFBBBF (UTF-8 BOM) because the buffer-to-string
+                // conversion translates it to FEFF (UTF-16 BOM)
+                if (entryData.charCodeAt(0) === 0xFEFF) {
+                    entryData = entryData.slice(1);
+                }
             }
             catch (e) {
                 this.logger.error(`${f} missing,looking for it in assets.`);

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -16,14 +16,18 @@ const expected = [
   'app/expected/en.json',
   'app/expected/fr.json',
   'app/expected/file.json',
-  'app/expected/prefixFileName.json'];
+  'app/expected/prefixFileName.json',
+  'app/expected/bom-bytes.json',
+];
 
 const actual = [
   'build/groupBy/countries/countries.json',
   'build/groupBy/locales/en.json',
   'build/groupBy/locales/fr.json',
   'build/files/file.json',
-  'build/prefixFileName/prefixFileName.json'];
+  'build/prefixFileName/prefixFileName.json',
+  'build/bom-bytes/bom-bytes.json',
+];
 
 describe('should merge json files', () => {
 
@@ -79,6 +83,15 @@ describe('MergeWebpackPlugin', () => {
     var file1Contents = fs.readFileSync(path.join(examplePath, expected[4])).toString();
     var file2Contents = fs.readFileSync(path.join(examplePath, actual[4])).toString();
     expect(file2Contents).to.equal(file1Contents);     
+    done();
+  })
+
+  it('should process jsons with BOM bytes', (done) => {
+    // These 2 files don't have BOM bytes on them.
+    // The file bundled via wepack.test.config.js does
+    var file1Contents = fs.readFileSync(path.join(examplePath, expected[5])).toString();
+    var file2Contents = fs.readFileSync(path.join(examplePath, actual[5])).toString();
+    expect(file2Contents).to.equal(file1Contents);
     done();
   })
 


### PR DESCRIPTION
## What
Addresses issue #22 - UTF8 with BOM not working

## Details
The _fix_ comes from https://github.com/sindresorhus/strip-bom/blob/master/index.js

## QA
I've update the unit test to include a file that contains the BOM bytes, along with some text combining English and Chinese.
![image](https://user-images.githubusercontent.com/2985436/45780092-a300ba80-bc11-11e8-9323-801e8699ba7d.png)

