### PR TITLE
Add support for custom "prefixFileName" function

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ new MergeJsonWebpackPlugin({
 | debug             | if true ,logs will be enabled, by default debug is false. |
 | encoding      	| Optional, encoding to be used default is utf-8.	|       |
 | globOptions      	| Optional, [glob options](https://github.com/isaacs/node-glob#options) to change pattern matching behavior.	|       |
-| prefixFileName            | if true ,file names will be prefixed to each file content and merged with outfile. |
+| prefixFileName    | Optional. If true, file names will be prefixed to each file content and merged with outfile<br><br>By default, the generated prefix is ​​simply the filename without the .json extension. If you want to customize the process of generating prefixes, you can pass a function as this option. The function should take exactly one argument (the file path) and returns the prefix.|
 
 ## Change Logs   
    
@@ -119,6 +119,7 @@ new MergeJsonWebpackPlugin({
 | 1.0.16            | Webpack 4 compatibile api changes  |
 | 1.0.17            | Filex extension check removed,file can be of any extention as long as content is json.Testcases also added  |
 | 1.0.18            | Bom issue fix #22 |
+| 1.0.19            | Support for custom "prefixFileName" function  |
 
 ## Sample
    To see sample you can navigate to example folder.

--- a/example/app/expected/prefixFileNameFn.json
+++ b/example/app/expected/prefixFileNameFn.json
@@ -1,0 +1,1 @@
+{"signIn":{"submit":"Sign in"},"signUp":{"submit":"Sign up"}}

--- a/example/app/prefixFileNameFn/sign_in.en.json
+++ b/example/app/prefixFileNameFn/sign_in.en.json
@@ -1,0 +1,3 @@
+{
+    "submit": "Sign in"
+}

--- a/example/app/prefixFileNameFn/sign_up.en.json
+++ b/example/app/prefixFileNameFn/sign_up.en.json
@@ -1,0 +1,3 @@
+{
+    "submit": "Sign up" 
+}

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -105,7 +105,7 @@ module.exports = {
              'app/prefixFileName/sign_up.json'
           ],
       "output": {
-        "fileName": "prefixfilename/prefixFileName.json"
+        "fileName": "prefixFileName/prefixFileName.json"
       }
     })
      

--- a/example/webpack.test.config.js
+++ b/example/webpack.test.config.js
@@ -108,7 +108,48 @@ module.exports = {
              'app/prefixFileName/sign_up.json'
           ],
       "output": {
-        "fileName": "prefixfilename/prefixFileName.json"
+        "fileName": "prefixFileName/prefixFileName.json"
+      }
+    }),
+
+   /**
+    *  Merge files and prefix them using the provided function
+    *  
+    *  for eg:
+    *   sign_in.en.json
+    *       {
+    *          "submit": "Sign in"
+    *       }
+    *   sign_up.en.json
+    *       {
+    *          "submit": "Sign up"
+    *       }
+    *       
+    *  The "prefixFileName" function: filePath => path.basename(filePath)
+    *                                                 .split('.')[0]
+    *                                                 .replace(/_+([a-z0-9])/ig, (_, char) => char.toUpperCase())
+    *   
+    *  --------OUTPUT----------
+    *  prefixFileNameFn.json
+    *       {
+    *          "signIn": {
+    *             "submit": "Sign in"
+    *          },
+    *          "signUp": {
+    *             "submit": "Sign up"
+    *          }
+    *       }
+    */
+    new MergeJsonWebpackPlugin({
+      "debug":false,
+      "prefixFileName": filePath => path.basename(filePath).split('.')[0]
+        .replace(/_+([a-z0-9])/ig, (_, char) => char.toUpperCase()),
+      "files": [
+             'app/prefixFileNameFn/sign_in.en.json',
+             'app/prefixFileNameFn/sign_up.en.json'
+          ],
+      "output": {
+        "fileName": "prefixFileNameFn/prefixFileNameFn.json"
       }
     }),
 

--- a/index.js
+++ b/index.js
@@ -148,7 +148,12 @@ class MergeJsonWebpackPlugin {
             try {
                 let fileContent = JSON.parse(entryData);
                 if (this.options.prefixFileName) {
-                    entryDataAsJSON[path.basename(f, allowedExtensions)] = fileContent;
+                    if (typeof this.options.prefixFileName === 'function') {
+                        entryDataAsJSON[this.options.prefixFileName(f)] = fileContent;
+                    }
+                    else {
+                        entryDataAsJSON[path.basename(f, allowedExtensions)] = fileContent;
+                    }
                 }
                 else {
                     entryDataAsJSON = fileContent;

--- a/index.ts
+++ b/index.ts
@@ -186,7 +186,11 @@ class MergeJsonWebpackPlugin {
             let fileContent = JSON.parse(entryData);
             //to prefix object with filename ,requirement as request in issue#31            
             if (this.options.prefixFileName) {
-                entryDataAsJSON[path.basename(f, allowedExtensions)] = fileContent;
+                if (typeof this.options.prefixFileName === 'function') {
+                    entryDataAsJSON[this.options.prefixFileName(f)] = fileContent;
+                } else {
+                    entryDataAsJSON[path.basename(f, allowedExtensions)] = fileContent;
+                }
             } else {
                 entryDataAsJSON = fileContent
             }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "merge-jsons-webpack-plugin",
   "description": "This plugin is used to merge json files into single json file,using glob or file names",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "author": {
     "email": "sudharsan_tk@yahoo.co.in",
     "name": "Sudharsan Tettu"

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -18,6 +18,7 @@ const expected = [
   'app/expected/file.json',
   'app/expected/prefixFileName.json',
   'app/expected/bom-bytes.json',
+  'app/expected/prefixFileNameFn.json'
 ];
 
 const actual = [
@@ -27,6 +28,7 @@ const actual = [
   'build/files/file.json',
   'build/prefixFileName/prefixFileName.json',
   'build/bom-bytes/bom-bytes.json',
+  'build/prefixFileNameFn/prefixFileNameFn.json'
 ];
 
 describe('should merge json files', () => {
@@ -92,6 +94,13 @@ describe('MergeWebpackPlugin', () => {
     var file1Contents = fs.readFileSync(path.join(examplePath, expected[5])).toString();
     var file2Contents = fs.readFileSync(path.join(examplePath, actual[5])).toString();
     expect(file2Contents).to.equal(file1Contents);
+    done();
+  })
+
+  it('should use the function to generate prefixes if it\'s provided', (done) => {
+    var file1Contents = fs.readFileSync(path.join(examplePath, expected[6])).toString();
+    var file2Contents = fs.readFileSync(path.join(examplePath, actual[6])).toString();
+    expect(file2Contents).to.equal(file1Contents);     
     done();
   })
 


### PR DESCRIPTION
For now, prefixes are generated using the hardcoded function which is not sufficient for some more complicated cases. 

Let's assume the following input files:
- example1.en.json
- example2.en.json

With true passed to the `prefixFileName` option, the result will be `{"example1.en": {...}, "example2.en": {...}}`. But when input files are grouped by the language-based pattern, the .en postfix is redundant.

The proposed solution is backward compatible and does not introduce any breaking change. Only if a function is passed as the `prefixFileName`  parameter, it will be called to generate a prefix.