### PR TITLE
Output formatting via 'space' parameter added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ new MergeJsonWebpackPlugin({
 | encoding      	| Optional, encoding to be used default is utf-8.	|       |
 | globOptions      	| Optional, [glob options](https://github.com/isaacs/node-glob#options) to change pattern matching behavior.	|       |
 | prefixFileName    | Optional. If true, file names will be prefixed to each file content and merged with outfile<br><br>By default, the generated prefix is ​​simply the filename without the .json extension. If you want to customize the process of generating prefixes, you can pass a function as this option. The function should take exactly one argument (the file path) and returns the prefix.|
+| space             | Optional. A `String` or `Number` object that's used to insert white space into the output JSON file for readability purposes. See [`space` parameter description on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Parameters) for details. |
 
 ## Change Logs   
    
@@ -120,6 +121,7 @@ new MergeJsonWebpackPlugin({
 | 1.0.17            | Filex extension check removed,file can be of any extention as long as content is json.Testcases also added  |
 | 1.0.18            | Bom issue fix #22 |
 | 1.0.19            | Support for custom "prefixFileName" function  |
+| 1.0.20            | Output formatting via `space` parameter added |
 
 ## Sample
    To see sample you can navigate to example folder.

--- a/example/app/expected/space.json
+++ b/example/app/expected/space.json
@@ -1,0 +1,8 @@
+{
+    "file1": "File1 ",
+    "file2": "File2",
+    "file3": "File3",
+    "name": "Text file ,not a json file extn.",
+    "greet_key": "Bonzour!",
+    "key_language": "French"
+}

--- a/example/webpack.test.config.js
+++ b/example/webpack.test.config.js
@@ -166,6 +166,22 @@ module.exports = {
         "fileName": "bom-bytes/bom-bytes.json"
       }
     }), 
+
+    /**
+     * Merge files and produce formatted output
+     */
+    new MergeJsonWebpackPlugin({
+      "debug":false,     
+      "files": ['app/files/file1.json',
+                'app/files/file2.json',
+                'app/files/file3.json',
+                'app/files/file4.txt',
+                'groupBy/locales/fr.json'],
+      "output": {
+        "fileName": "space/space.json"
+      },
+      "space": 4
+    }), 
      
   ]
 };

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ class MergeJsonWebpackPlugin {
                 contents.forEach((content) => {
                     mergedContents = this.mergeDeep(mergedContents, content);
                 });
-                mergedContents = JSON.stringify(mergedContents);
+                mergedContents = JSON.stringify(mergedContents, null, this.options.space);
                 resolve(new Response(outputPath, mergedContents));
             })
                 .catch((error) => {

--- a/index.ts
+++ b/index.ts
@@ -130,7 +130,7 @@ class MergeJsonWebpackPlugin {
                 contents.forEach((content) => {
                     mergedContents = this.mergeDeep(mergedContents, content);
                 });
-                mergedContents = JSON.stringify(mergedContents);
+                mergedContents = JSON.stringify(mergedContents, null, this.options.space);
                 resolve(new Response(outputPath, mergedContents));
             })
             .catch((error) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "merge-jsons-webpack-plugin",
   "description": "This plugin is used to merge json files into single json file,using glob or file names",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "author": {
     "email": "sudharsan_tk@yahoo.co.in",
     "name": "Sudharsan Tettu"

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -18,7 +18,8 @@ const expected = [
   'app/expected/file.json',
   'app/expected/prefixFileName.json',
   'app/expected/bom-bytes.json',
-  'app/expected/prefixFileNameFn.json'
+  'app/expected/prefixFileNameFn.json',
+  'app/expected/space.json'
 ];
 
 const actual = [
@@ -28,7 +29,8 @@ const actual = [
   'build/files/file.json',
   'build/prefixFileName/prefixFileName.json',
   'build/bom-bytes/bom-bytes.json',
-  'build/prefixFileNameFn/prefixFileNameFn.json'
+  'build/prefixFileNameFn/prefixFileNameFn.json',
+  'build/space/space.json'
 ];
 
 describe('should merge json files', () => {
@@ -101,6 +103,13 @@ describe('MergeWebpackPlugin', () => {
     var file1Contents = fs.readFileSync(path.join(examplePath, expected[6])).toString();
     var file2Contents = fs.readFileSync(path.join(examplePath, actual[6])).toString();
     expect(file2Contents).to.equal(file1Contents);     
+    done();
+  })
+
+  it('should format output if space parameter is provided', (done) => {
+    var file1Contents = fs.readFileSync(path.join(examplePath, expected[7])).toString();
+    var file2Contents = fs.readFileSync(path.join(examplePath, actual[7])).toString();
+    expect(file2Contents).to.equal(file1Contents);
     done();
   })
 


### PR DESCRIPTION
Added a parameter to make merged JSON formatted.

It simply passes `space` parameter to the `JSON.stringify` call.

This may also address #50.

